### PR TITLE
Add duplicate entry check

### DIFF
--- a/tests/test_bioversions.py
+++ b/tests/test_bioversions.py
@@ -4,9 +4,34 @@
 
 import datetime
 import unittest
+from collections import Counter
+
+from tabulate import tabulate
 
 import bioversions
+from bioversions.resources import load_versions
 from bioversions.sources import BioGRIDGetter, WikiPathwaysGetter
+
+
+class TestData(unittest.TestCase):
+    """Tests for the data."""
+
+    def test_duplicates(self):
+        """Test there are no duplicate prefixes."""
+        versions = load_versions()
+        counter = Counter(
+            entry["prefix"]
+            for entry in versions["database"]
+            if entry.get("prefix")
+        )
+        duplicates = {
+            prefix: count
+            for prefix, count in counter.items()
+            if count > 1
+        }
+        if duplicates:
+            t = tabulate(duplicates.items(), headers=["Prefix", "Count"])
+            self.fail(f"Found duplicates for {len(duplicates)} prefixes:\n\n{t}")
 
 
 class TestGetter(unittest.TestCase):


### PR DESCRIPTION
- [x] add unit test
- [ ] manually fix all data (this shouldn't happen again since the reason was because of old code for matching)