### PR TITLE
Added Bioschemas annotation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,13 +27,19 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
     {% assign latest = entry.releases | last %}
     <tr>
         <td>
-          <script type="application/ld+json">{
-            "@context":"https://schema.org", "@type":"Dataset",
-            "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Dataset/0.4-DRAFT/" },
-            "name":"{{ entry.name }}",
-            "url":"https://bioregistry.io/{{ entry.prefix }}",
-            "version":"{{ latest.version }}"
-          }</script>
+            <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type":"Dataset",
+                "http://purl.org/dc/terms/conformsTo": {
+                    "@type": "CreativeWork", 
+                    "@id": "https://bioschemas.org/profiles/Dataset/0.4-DRAFT/"
+                },
+                "name": "{{ entry.name }}",
+                "url": "https://bioregistry.io/{{ entry.prefix }}",
+                "version": "{{ latest.version }}"
+            }
+            </script>
         {% if entry.prefix %}
             <a href="https://bioregistry.io/{{ entry.prefix }}"><code>{{ entry.prefix }}</code></a>
         {% elsif entry.key %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,10 +43,10 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
             </script>
             <a href="https://bioregistry.io/{{ entry.prefix }}"><code>{{ entry.prefix }}</code></a>
         {% elsif entry.key %}
-            <!-- 
+            {% comment %} 
                todo: add Bioschemas for non-prefixed resources. 
                will be easier after https://github.com/biopragmatics/bioversions/issues/13
-            -->
+            {% endcomment %}
             {{ entry.key }}
         {% endif %}
         </td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,13 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
     {% assign latest = entry.releases | last %}
     <tr>
         <td>
+          <script type="application/ld+json">{
+            "@context":"https://schema.org", "@type":"Dataset",
+            "http://purl.org/dc/terms/conformsTo": { "@type": "CreativeWork", "@id": "https://bioschemas.org/profiles/Dataset/0.4-DRAFT/" },
+            "name":"{{ entry.name }}",
+            "url":"https://bioregistry.io/{{ entry.prefix }}",
+            "version":"{{ latest.version }}"
+          }</script>
         {% if entry.prefix %}
             <a href="https://bioregistry.io/{{ entry.prefix }}"><code>{{ entry.prefix }}</code></a>
         {% elsif entry.key %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,13 +40,13 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
             <script type="application/ld+json">
             {
                 "@context": "https://schema.org",
-                "@type":"Dataset",
+                "@type": "Dataset",
+                "@id": "https://bioregistry.io/{{ entry.prefix }}",
                 "http://purl.org/dc/terms/conformsTo": {
                     "@type": "CreativeWork", 
                     "@id": "https://bioschemas.org/profiles/Dataset/0.4-DRAFT/"
                 },
                 "name": "{{ entry.name }}",
-                "url": "https://bioregistry.io/{{ entry.prefix }}",
                 "version": "{{ latest.version }}"
             }
             </script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,10 +42,6 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
                 "@context": "https://schema.org",
                 "@type": "Dataset",
                 "@id": "https://bioregistry.io/{{ entry.prefix }}",
-                "http://purl.org/dc/terms/conformsTo": {
-                    "@type": "CreativeWork", 
-                    "@id": "https://bioschemas.org/profiles/Dataset/0.4-DRAFT/"
-                },
                 "name": "{{ entry.name }}",
                 "version": "{{ latest.version }}"
             }

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
     {% assign latest = entry.releases | last %}
     <tr>
         <td>
+        {% if entry.prefix %}
             <script type="application/ld+json">
             {
                 "@context": "https://schema.org",
@@ -40,9 +41,12 @@ date when the latest version was retrieved, 💡 means the date was inferred by 
                 "version": "{{ latest.version }}"
             }
             </script>
-        {% if entry.prefix %}
             <a href="https://bioregistry.io/{{ entry.prefix }}"><code>{{ entry.prefix }}</code></a>
         {% elsif entry.key %}
+            <!-- 
+               todo: add Bioschemas for non-prefixed resources. 
+               will be easier after https://github.com/biopragmatics/bioversions/issues/13
+            -->
             {{ entry.key }}
         {% endif %}
         </td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,15 @@ This site and accompanying package are a resource for informing you what the lat
 is. Last updated on {{ site.data.versions.annotations.date }} (revision {{ site.data.versions.annotations.revision }})
 by {{ site.data.versions.annotations.author }}.
 
+This site also includes [Bioschemas](https://bioschemas.org/) annotations, which
+aims to improve the findability of life sciences resources such as datasets,
+software, and training materials. These annotations can either appear on the
+original site, or on a website (like this one) that indexes it or provides
+additional information. The further information here, for example, is the link
+to the BioRegistry. The JSON-LD annotation will make it easier for other
+tools to recognize the content of the table. This includes the [Google Dataset
+finder](https://datasetsearch.research.google.com/), besides Bioschemas itself.
+
 Legend: 📥 means the resource reports the date of each release, 📅 means the date of release was inferred based on the
 date when the latest version was retrieved, 💡 means the date was inferred by the version string.
 


### PR DESCRIPTION
From the [Bioschemas website](https://bioschemas.org/): 

```
Bioschemas aims to improve the Findability on the Web of life sciences resources such as datasets,
software, and training materials. 
```

This can be on the original website itself (like on WikiPathways), but also on website that index it or have further information about it. The further information here, for example, is the link to the BioRegistry. The JSON-LD annotation will make it easier for other tools to recognize the content of the table. This includes the [Google Dataset finder](https://datasetsearch.research.google.com/), besides Bioschemas itself.