### PR TITLE
Update UMLS version path in HTML

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     pyyaml
     tqdm
     bioregistry[align]>=0.10.0
+    pandas  # remove after deploying https://github.com/biopragmatics/bioregistry/pull/1047
     lxml
     psycopg2-binary
 

--- a/src/bioversions/sources/umls.py
+++ b/src/bioversions/sources/umls.py
@@ -23,8 +23,14 @@ class UMLSGetter(Getter):
     def get(self) -> datetime:
         """Get the latest UMLS version number."""
         soup = get_soup(URL)
-        raw_version = soup.find("div", {"id": "body"}).find("h2")
-        return raw_version.text.split()[0]
+        version_tag = (
+            soup.find("main")
+            .find("div", {"class": "grid-row grid-gap-1"})
+            .find("div", {"class": "tablet:grid-col-12"})
+            .find("h2")
+        )
+        version = version_tag.text.split()[0]
+        return version
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The UMLS version page has changed requiring an update to the HTML path to the h2 containing the version. With the change in this PR, I get "2023AB" for:

```python
from bioversions.sources import umls
umls.UMLSGetter().get()
```