### PR TITLE
Fix URL for rgd

### DIFF
--- a/src/bioversions/sources/rgd.py
+++ b/src/bioversions/sources/rgd.py
@@ -10,7 +10,7 @@ __all__ = [
     "RGDGetter",
 ]
 
-URL = "https://download.rgd.mcw.edu/data_release/GENES.RAT.txt"
+URL = "https://download.rgd.mcw.edu/data_release/GENES_RAT.txt"
 
 
 class RGDGetter(Getter):


### PR DESCRIPTION
This PR fixes the URL for the rgd resource file.

See also: https://github.com/biopragmatics/pyobo/pull/188