### PR TITLE
Fix dgi

### DIFF
--- a/src/bioversions/sources/dgi.py
+++ b/src/bioversions/sources/dgi.py
@@ -2,8 +2,6 @@
 
 """A getter for the `Drug Gene Interaction Database (DGI-DB) <http://www.dgidb.org>`_."""
 
-import os
-
 import bs4
 import dateutil.parser
 import requests

--- a/src/bioversions/sources/dgi.py
+++ b/src/bioversions/sources/dgi.py
@@ -5,11 +5,12 @@
 import os
 
 import bs4
+import dateutil.parser
 import requests
 
 from bioversions.utils import Getter, VersionType
 
-DOWNLOADS_PAGE = "https://www.dgidb.org/downloads"
+GITHUB_PAGE = "https://github.com/dgidb/dgidb-v5"
 
 
 class DGIGetter(Getter):
@@ -21,14 +22,14 @@ class DGIGetter(Getter):
 
     def get(self):
         """Get the latest DGI version number."""
-        res = requests.get(DOWNLOADS_PAGE)
-        soup = bs4.BeautifulSoup(res.content, parser="lxml", features="lxml")
-        cells = list(soup.select("table#tsv_downloads tbody tr:first-child td:nth-child(2) a"))
-        if 1 != len(cells):
+        res = requests.get(GITHUB_PAGE)
+        soup = bs4.BeautifulSoup(res.content)
+        time_tag = soup.find("relative-time")
+        if time_tag is None:
             raise ValueError
-        cell = cells[0]
-        href = cell["href"]
-        version = os.path.dirname(os.path.relpath(href, "data/monthly_tsvs"))
+        datetime_str = time_tag.attrs["datetime"]
+        dt_obj = dateutil.parser.parse(datetime_str)
+        version = dt_obj.strftime(self.date_version_fmt)
         return version
 
 


### PR DESCRIPTION
This PR updates dgi since its v5 remake of their homepage.

The downloads page contains all the relevant information to get a the version, but requires JS to load properly (it looks like they've implemented it as a [SPA](https://developer.mozilla.org/en-US/docs/Glossary/SPA)), so using python's `requests` won't work. However, the link to the latest release on github seems to correlate in date with the latest data release, so I opted to just look at the release date on their github homepage.
![image](https://github.com/user-attachments/assets/7143926a-2fca-484e-83ef-5ecc83ce7fce)
