### PR TITLE
Remove requirement on requests-ftp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ license = { file = "LICENSE" }
 requires-python = ">=3.9"
 dependencies = [
     "requests",
-    "requests_ftp",
     "beautifulsoup4",
     "cachier>=2.2.1",
     "pystow>=0.1.0",

--- a/src/bioversions/sources/expasy.py
+++ b/src/bioversions/sources/expasy.py
@@ -10,7 +10,7 @@ __all__ = [
     "ExPASyGetter",
 ]
 
-URL = "ftp://ftp.expasy.org/databases/enzyme/enzuser.txt"
+URL = "https://ftp.expasy.org/databases/enzyme/enzuser.txt"
 
 
 class ExPASyGetter(Getter):

--- a/src/bioversions/utils.py
+++ b/src/bioversions/utils.py
@@ -11,7 +11,6 @@ import bioregistry
 import pydantic
 import pystow
 import requests
-import requests_ftp
 from bs4 import BeautifulSoup
 from cachier import cachier
 
@@ -19,8 +18,6 @@ BIOVERSIONS_HOME = pystow.join("bioversions")
 HERE = os.path.abspath(os.path.dirname(__file__))
 DOCS = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir, "docs"))
 IMG = os.path.join(DOCS, "img")
-
-requests_ftp.monkeypatch_session()
 
 
 class VersionType(enum.Enum):


### PR DESCRIPTION
This module relies on cgi, which was removed in py313 and also most FTP servers are getting replaced with HTTP anyway