### PR TITLE
Fix error handling and failure output

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -1,7 +1,7 @@
 annotations:
-  author: runner
-  date: '2025-01-15'
-  revision: 902
+  author: cthoyt
+  date: '2025-01-28'
+  revision: 903
 database:
 - name: A nomenclatural ontology for biological names
   prefix: nomen
@@ -111,6 +111,9 @@ database:
   - homepage: https://antibodyregistry.org/
     retrieved: '2025-01-15'
     version: '2025-01-14'
+  - homepage: https://antibodyregistry.org/
+    retrieved: '2025-01-28'
+    version: '2025-01-27'
   vtype: date
 - name: Apollo Structured Vocabulary
   prefix: apollosv
@@ -1099,6 +1102,8 @@ database:
     version: '2.232'
   - retrieved: '2025-01-12'
     version: '2.233'
+  - retrieved: '2025-01-28'
+    version: '2.234'
   vtype: date
 - name: Clinical Trials Ontology
   prefix: cto
@@ -2247,6 +2252,8 @@ database:
     version: '4.190'
   - retrieved: '2025-01-12'
     version: '4.191'
+  - retrieved: '2025-01-28'
+    version: '4.192'
   vtype: date
 - name: Experimental Factor Ontology
   prefix: efo
@@ -2499,6 +2506,8 @@ database:
     version: '2024-12-05'
   - retrieved: '2025-01-05'
     version: '2024-12-31'
+  - retrieved: '2025-01-28'
+    version: '2025-01-14'
   vtype: date
 - name: Flora Phenotype Ontology
   prefix: flopo
@@ -3586,6 +3595,8 @@ database:
     version: ''
   - retrieved: '2025-01-14'
     version: '2024-12-16'
+  - retrieved: '2025-01-28'
+    version: '2025-01-24'
   vtype: date
 - name: KEGG
   prefix: kegg.pathway
@@ -3878,6 +3889,8 @@ database:
     version: '2.144'
   - retrieved: '2024-12-15'
     version: '2.145'
+  - retrieved: '2025-01-28'
+    version: '2.146'
   vtype: date
 - name: Medaka Developmental Stages
   prefix: olatdv
@@ -5231,6 +5244,8 @@ database:
     version: '2025-01-10'
   - retrieved: '2025-01-15'
     version: '2025-01-13'
+  - retrieved: '2025-01-28'
+    version: '2025-01-24'
   vtype: date
 - name: 'OntoAvida: ontology for Avida digital evolution platform'
   prefix: ontoavida
@@ -6631,6 +6646,8 @@ database:
     version: '2025-01-03'
   - retrieved: '2025-01-14'
     version: '2025-01-10'
+  - retrieved: '2025-01-28'
+    version: '2025-01-24'
   vtype: date
 - name: Rat Strain Ontology
   prefix: rs
@@ -6679,6 +6696,8 @@ database:
     version: '6.236'
   - retrieved: '2024-12-15'
     version: '6.238'
+  - retrieved: '2025-01-28'
+    version: '6.239'
   vtype: date
 - name: Reactome
   prefix: reactome
@@ -8370,6 +8389,8 @@ database:
     version: '2025-01-14'
   - retrieved: '2025-01-15'
     version: '2025-01-15'
+  - retrieved: '2025-01-28'
+    version: '2025-01-28'
   vtype: date
 - name: SWO (The Software Ontology)
   prefix: swo
@@ -8757,6 +8778,8 @@ database:
     version: '2024-09-04'
   - retrieved: '2024-11-10'
     version: '2024-11-02'
+  - retrieved: '2025-01-28'
+    version: '2025-01-11'
   vtype: date
 - name: Unified phenotype ontology (uPheno)
   prefix: upheno
@@ -11165,6 +11188,8 @@ database:
     version: '2025-01-12'
   - retrieved: '2025-01-15'
     version: '2025-01-13'
+  - retrieved: '2025-01-28'
+    version: '2025-01-27'
   vtype: date
 - name: Zebrafish Phenotype Ontology
   prefix: zp

--- a/docs/failures.md
+++ b/docs/failures.md
@@ -1,7 +1,48 @@
 # Summary of Errors
 
+- CiVIC - issue parsing CiVIC: 'data'
 - DisGeNet - failed to resolve DisGeNet
 - DrugBank - failed to resolve DrugBank
+
+## CiVIC
+
+Using class: `CiVICGetter`
+
+```python-traceback
+Traceback (most recent call last):
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 218, in _iter_versions
+    yv = resolve(cls.name)
+         ^^^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 171, in resolve
+    return _resolve_helper_cached(name)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/cachier/core.py", line 258, in func_wrapper
+    return _calc_entry(core, key, func, args, kwds)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/cachier/core.py", line 61, in _calc_entry
+    func_res = func(*args, **kwds)
+               ^^^^^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 178, in _resolve_helper_cached
+    return _resolve_helper(name)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 184, in _resolve_helper
+    return getter.resolve()
+           ^^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 216, in resolve
+    version=cls.version,
+            ^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 94, in version
+    if isinstance(cls._cache_prop, str):
+                  ^^^^^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 88, in _cache_prop
+    cls._cache = cls().get()
+                 ^^^^^^^^^^^
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/civic.py", line 41, in get
+    value = res.json()["data"]["dataReleases"][1]["name"]
+            ~~~~~~~~~~^^^^^^^^
+KeyError: 'data'
+
+```
 
 ## DisGeNet
 
@@ -9,53 +50,53 @@ Using class: `DisGeNetGetter`
 
 ```python-traceback
 Traceback (most recent call last):
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/requests/models.py", line 974, in json
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/requests/models.py", line 974, in json
     return complexjson.loads(self.text, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/json/__init__.py", line 346, in loads
+  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/__init__.py", line 346, in loads
     return _default_decoder.decode(s)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/json/decoder.py", line 338, in decode
+  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/decoder.py", line 338, in decode
     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/json/decoder.py", line 356, in raw_decode
+  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/decoder.py", line 356, in raw_decode
     raise JSONDecodeError("Expecting value", s, err.value) from None
 json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
 
 During handling of the above exception, another exception occurred:
 
 Traceback (most recent call last):
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 218, in _iter_versions
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 218, in _iter_versions
     yv = resolve(cls.name)
          ^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 171, in resolve
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 171, in resolve
     return _resolve_helper_cached(name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/cachier/core.py", line 258, in func_wrapper
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/cachier/core.py", line 258, in func_wrapper
     return _calc_entry(core, key, func, args, kwds)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/cachier/core.py", line 61, in _calc_entry
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/cachier/core.py", line 61, in _calc_entry
     func_res = func(*args, **kwds)
                ^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 178, in _resolve_helper_cached
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 178, in _resolve_helper_cached
     return _resolve_helper(name)
            ^^^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 184, in _resolve_helper
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 184, in _resolve_helper
     return getter.resolve()
            ^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/utils.py", line 216, in resolve
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 216, in resolve
     version=cls.version,
             ^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/utils.py", line 94, in version
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 94, in version
     if isinstance(cls._cache_prop, str):
                   ^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/utils.py", line 88, in _cache_prop
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 88, in _cache_prop
     cls._cache = cls().get()
                  ^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/disgenet.py", line 24, in get
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/disgenet.py", line 24, in get
     res_json = res.json()
                ^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/requests/models.py", line 978, in json
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/requests/models.py", line 978, in json
     raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
 requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
 
@@ -67,38 +108,37 @@ Using class: `DrugBankGetter`
 
 ```python-traceback
 Traceback (most recent call last):
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 218, in _iter_versions
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 218, in _iter_versions
     yv = resolve(cls.name)
          ^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 171, in resolve
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 171, in resolve
     return _resolve_helper_cached(name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/cachier/core.py", line 258, in func_wrapper
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/cachier/core.py", line 258, in func_wrapper
     return _calc_entry(core, key, func, args, kwds)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/cachier/core.py", line 61, in _calc_entry
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/cachier/core.py", line 61, in _calc_entry
     func_res = func(*args, **kwds)
                ^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 178, in _resolve_helper_cached
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 178, in _resolve_helper_cached
     return _resolve_helper(name)
            ^^^^^^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/__init__.py", line 184, in _resolve_helper
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/__init__.py", line 184, in _resolve_helper
     return getter.resolve()
            ^^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/utils.py", line 216, in resolve
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 216, in resolve
     version=cls.version,
             ^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/utils.py", line 94, in version
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 94, in version
     if isinstance(cls._cache_prop, str):
                   ^^^^^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/utils.py", line 88, in _cache_prop
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/utils.py", line 88, in _cache_prop
     cls._cache = cls().get()
                  ^^^^^^^^^^^
-  File "/home/runner/work/bioversions/bioversions/src/bioversions/sources/drugbank.py", line 28, in get
+  File "/Users/cthoyt/dev/bioversions/src/bioversions/sources/drugbank.py", line 28, in get
     res.raise_for_status()
-  File "/home/runner/work/bioversions/bioversions/.tox/update/lib/python3.12/site-packages/requests/models.py", line 1024, in raise_for_status
+  File "/Users/cthoyt/.virtualenvs/biopragmatics/lib/python3.12/site-packages/requests/models.py", line 1024, in raise_for_status
     raise HTTPError(http_error_msg, response=self)
 requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://go.drugbank.com/releases.json
 
 ```
-

--- a/src/bioversions/resources/update.py
+++ b/src/bioversions/resources/update.py
@@ -106,7 +106,7 @@ def _update(force: bool):  # noqa:C901
         for t in failure_tuples:
             text += f"## {t.name}\n\nUsing class: `{t.clstype}`\n\n"
             text += f"```python-traceback\n{t.trace}\n```\n\n"
-        FAILURES_PATH.write_text(text)
+        FAILURES_PATH.write_text(text.rstrip() + "\n")
 
 
 def _log_update(bv) -> None:

--- a/src/bioversions/resources/versions.json
+++ b/src/bioversions/resources/versions.json
@@ -1,8 +1,8 @@
 {
   "annotations": {
-    "revision": 902,
-    "date": "2025-01-15",
-    "author": "runner"
+    "revision": 903,
+    "date": "2025-01-28",
+    "author": "cthoyt"
   },
   "database": [
     {
@@ -203,6 +203,11 @@
         {
           "retrieved": "2025-01-15",
           "version": "2025-01-14",
+          "homepage": "https://antibodyregistry.org/"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-27",
           "homepage": "https://antibodyregistry.org/"
         }
       ],
@@ -2022,6 +2027,10 @@
         {
           "retrieved": "2025-01-12",
           "version": "2.233"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2.234"
         }
       ],
       "vtype": "date"
@@ -4109,6 +4118,10 @@
         {
           "retrieved": "2025-01-12",
           "version": "4.191"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "4.192"
         }
       ],
       "vtype": "date"
@@ -4608,6 +4621,10 @@
         {
           "retrieved": "2025-01-05",
           "version": "2024-12-31"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-14"
         }
       ],
       "vtype": "date"
@@ -6510,6 +6527,10 @@
         {
           "retrieved": "2025-01-14",
           "version": "2024-12-16"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-24"
         }
       ],
       "name": "ITIS",
@@ -7057,6 +7078,10 @@
         {
           "retrieved": "2024-12-15",
           "version": "2.145"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2.146"
         }
       ],
       "vtype": "date"
@@ -9441,6 +9466,10 @@
         {
           "retrieved": "2025-01-15",
           "version": "2025-01-13"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-24"
         }
       ],
       "name": "Online Mendelian Inheritance in Man",
@@ -11998,6 +12027,10 @@
         {
           "retrieved": "2025-01-14",
           "version": "2025-01-10"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-24"
         }
       ],
       "name": "Rat Genome Database",
@@ -12095,6 +12128,10 @@
         {
           "retrieved": "2024-12-15",
           "version": "6.238"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "6.239"
         }
       ],
       "vtype": "date"
@@ -15382,6 +15419,10 @@
         {
           "retrieved": "2025-01-15",
           "version": "2025-01-15"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-28"
         }
       ],
       "name": "SwissLipids",
@@ -16125,6 +16166,10 @@
         {
           "retrieved": "2024-11-10",
           "version": "2024-11-02"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-11"
         }
       ],
       "name": "Unified Phenotype Ontology",
@@ -20516,6 +20561,10 @@
         {
           "retrieved": "2025-01-15",
           "version": "2025-01-13"
+        },
+        {
+          "retrieved": "2025-01-28",
+          "version": "2025-01-27"
         }
       ],
       "name": "Zebrafish Information Network",

--- a/src/bioversions/sources/__init__.py
+++ b/src/bioversions/sources/__init__.py
@@ -220,7 +220,7 @@ def _iter_versions(
             msg = f"failed to resolve {cls.name}"
             tqdm.write(msg)
             yield FailureTuple(cls.name, cls.__name__, msg, traceback.format_exc())
-        except ValueError as e:
+        except (ValueError, KeyError) as e:
             msg = f"issue parsing {cls.name}: {e}"
             tqdm.write(msg)
             yield FailureTuple(cls.name, cls.__name__, msg, traceback.format_exc())


### PR DESCRIPTION
1. CIVIC is raising a key error, now the update workflow catches this
2. The failure sheet had an extra newline at the end, now it does not