### PR TITLE
Updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "more_click",
     "pyyaml",
     "tqdm",
-    "bioregistry[align]>=0.13.0",
+    "bioregistry[align]>=0.13.47",
     "lxml",
     "pydantic>=2.0",
     "psycopg2-binary",

--- a/src/bioversions/sources/__init__.py
+++ b/src/bioversions/sources/__init__.py
@@ -155,8 +155,6 @@ __all__ = [
 #: These are broken beyond fixing at the moment
 SKIPPED = {
     DrugBankGetter,
-    PathwayCommonsGetter,
-    DisGeNetGetter,
     # Upper-level classes
     OBOFoundryGetter,
     UnversionedGetter,
@@ -185,8 +183,10 @@ def resolve(name: str | type[Getter], strict: Literal[True] = ...) -> VersionRes
 @lru_cache(None)
 def resolve(name: str | type[Getter], strict: bool = True) -> VersionResult | None:
     """Resolve the database name to a :class:`Bioversion` instance."""
-    getter = getter_resolver.lookup(name)
     try:
+        # this can throw a key error if it can't be looked up
+        getter = getter_resolver.lookup(name)
+        # this can throw all sorts of errors during resolution
         rv = getter.resolve()
     except Exception:
         if strict:

--- a/src/bioversions/sources/flybase.py
+++ b/src/bioversions/sources/flybase.py
@@ -2,7 +2,7 @@
 
 import re
 
-from bioversions.utils import Getter, VersionType, get_soup
+from bioversions.utils import HUMAN_BROWSER_AGENT, Getter, VersionType, get_soup
 
 __all__ = [
     "FlybaseGetter",
@@ -10,10 +10,6 @@ __all__ = [
 
 URL = "https://s3ftp.flybase.org/releases/"
 PATTERN = re.compile(r"FB\d{4}_\d{2}")
-AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
-)
 
 
 class FlybaseGetter(Getter):
@@ -26,7 +22,7 @@ class FlybaseGetter(Getter):
 
     def get(self) -> str:
         """Get the latest FlyBase version."""
-        soup = get_soup(URL, user_agent=AGENT)
+        soup = get_soup(URL, user_agent=HUMAN_BROWSER_AGENT)
         releases = [
             match.group().removeprefix("FB")
             for anchor_tag in soup.find_all("a", href=True)

--- a/src/bioversions/sources/ols.py
+++ b/src/bioversions/sources/ols.py
@@ -5,7 +5,6 @@ from typing import ClassVar, cast
 
 import bioregistry
 from bioregistry.external.ols import get_ols_processing
-from bioregistry.resolve import get_name
 from class_resolver import ClassResolver
 
 from bioversions.utils import Getter, VersionType
@@ -15,14 +14,11 @@ logger = logging.getLogger(__name__)
 ols_processing = get_ols_processing()
 
 
-def _get_version_type(bioregistry_id: str) -> VersionType | None:
-    ols_id = bioregistry.get_ols_prefix(bioregistry_id)
-    if ols_id is None:
-        raise ValueError(f"Missing OLS prefix for bioregistry:{bioregistry_id}")
+def _get_version_type(resource: bioregistry.Resource, ols_id: str) -> VersionType | None:
     ols_config = ols_processing.get(ols_id)
     if ols_config is None:
         raise ValueError(
-            f"Missing OLS configuration for bioregistry:{bioregistry_id} / ols:{ols_id}"
+            f"Missing OLS configuration for bioregistry:{resource.prefix} / ols:{ols_id}"
         )
 
     ols_version_type = ols_config.version_type
@@ -32,60 +28,57 @@ def _get_version_type(bioregistry_id: str) -> VersionType | None:
     elif ols_version_type:
         return VersionType[ols_version_type.name]
     else:
-        logger.warning("[%s] missing version type", bioregistry_id)
+        logger.warning("[%s] missing version type", resource.prefix)
         return None
 
 
-def make_ols_getter(bioregistry_id: str) -> type[Getter] | None:
+def make_ols_getter(resource: bioregistry.Resource) -> type[Getter] | None:
     """Make a getter from OLS."""
-    ols_id = bioregistry.get_ols_prefix(bioregistry_id)
+    ols_id = resource.get_ols_prefix()
     if ols_id is None:
         return None
 
-    resource = bioregistry.get_resource(bioregistry_id)
-    if resource is None:
-        logger.warning(f"Invalid bioregistry prefix: {bioregistry_id}")
-        return None
     if resource.ols is None:
-        logger.warning("[%s] Missing information in OLS", bioregistry_id)
-        return None
+        raise RuntimeError(f"{resource.prefix} is mapped to OLS  {ols_id} but is missing OLS data")
+
     version = resource.ols.get("version")
     if version is None:
-        logger.debug("[%s] no OLS version", bioregistry_id)
+        logger.debug("[%s] no OLS version", resource)
         return None
-
-    _brid = bioregistry_id
-    _name = get_name(_brid)
+    _name = resource.get_name()
     if _name is None:
         return None
-    _version_type = _get_version_type(bioregistry_id)
+    _version_type = _get_version_type(resource, ols_id=ols_id)
     if _version_type is None:
         return None
 
     class OlsGetter(Getter):
         """A getter for OLS data from the Bioregistry."""
 
-        bioregistry_id: ClassVar[str] = _brid
-        name: ClassVar[str] = _name
-        version_type: ClassVar[str] = _version_type  # type:ignore
+        bioregistry_id: ClassVar[str] = resource.prefix
+        name: ClassVar[str] = cast(str, _name)
+        version_type: ClassVar[VersionType] = cast(VersionType, _version_type)
 
         def get(self) -> str:
             """Get the version from the Bioregistry."""
             return cast(str, version)
 
-    return type(f"{_brid.title()}Getter", (OlsGetter,), locals())
+    class_name = f"{resource.prefix.title()}Getter"
+    return type(class_name, (OlsGetter,), locals())
 
 
 def extend_ols(version_getter_resolver: ClassResolver[Getter]) -> None:
     """Add OLS lookup."""
-    for bioregistry_id in bioregistry.read_registry():
+    for resource in bioregistry.resources():
+        if resource.provides or resource.has_canonical or resource.part_of:
+            continue
         try:
-            version_getter_resolver.lookup(bioregistry_id)
+            version_getter_resolver.lookup(resource.prefix)
         except KeyError:
             pass
         else:
             continue
-        getter = make_ols_getter(bioregistry_id)
+        getter = make_ols_getter(resource)
         if getter is None:
             continue
         version_getter_resolver.register(getter)

--- a/src/bioversions/sources/pathwaycommons.py
+++ b/src/bioversions/sources/pathwaycommons.py
@@ -1,12 +1,12 @@
 """A getter for Pathway Commons."""
 
-from bioversions.utils import Getter, VersionType, find_soup_text, get_soup
+from bioversions.utils import Getter, VersionType, get_soup
 
 __all__ = [
     "PathwayCommonsGetter",
 ]
 
-URL = "https://www.pathwaycommons.org/"
+URL = "https://download.baderlab.org/PathwayCommons/PC2/"
 
 
 class PathwayCommonsGetter(Getter):
@@ -18,10 +18,15 @@ class PathwayCommonsGetter(Getter):
     def get(self) -> str:
         """Get the latest Pathway Commons version number."""
         soup = get_soup(URL)
-        boost_text = find_soup_text(soup, {"class": "boost"})
-        boost_text = boost_text[len("Version ") :]
-        boost_text = boost_text.split(":")[0]
-        return boost_text
+        hrefs = {
+            int(anchor.attrs["href"].lstrip("v").rstrip("/"))
+            for anchor in soup.find_all("a")
+            if anchor.attrs is not None
+            and "href" in anchor.attrs
+            and isinstance(anchor.attrs["href"], str)
+            and anchor.attrs["href"].startswith("v")
+        }
+        return str(max(hrefs))
 
 
 if __name__ == "__main__":

--- a/src/bioversions/utils.py
+++ b/src/bioversions/utils.py
@@ -48,6 +48,11 @@ IMG = os.path.join(DOCS, "img")
 
 BIOVERSIONS_USER_AGENT = f"bioversions v{VERSION}"
 
+HUMAN_BROWSER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
+)
+
 
 def get_soup(
     url: str,

--- a/tests/test_bioversions.py
+++ b/tests/test_bioversions.py
@@ -51,7 +51,7 @@ class TestGetter(unittest.TestCase):
         prefixes = [
             "reactome",
             "kegg",
-            "orphanet.ordo",
+            "orpha",
         ]
         for prefix in prefixes:
             with self.subTest(prefix=prefix):

--- a/tests/test_bioversions.py
+++ b/tests/test_bioversions.py
@@ -8,6 +8,7 @@ import bioregistry
 
 import bioversions
 from bioversions.sources import BioGRIDGetter, WikiPathwaysGetter, getter_resolver
+from bioversions.sources.ols import make_ols_getter
 from bioversions.utils import get_obo_version, get_obograph_json_version, get_owl_xml_version
 
 YYYYMMDD = re.compile("\\d{4}-\\d{2}-\\d{2}")
@@ -25,11 +26,32 @@ class TestGetter(unittest.TestCase):
             with self.subTest(name=getter.name):
                 self.assertIn(getter.bioregistry_id, prefixes)
 
+    def test_ols(self) -> None:
+        """Test getting getters."""
+        non_canonical_resource = bioregistry.get_resource("orphanet.ordo", strict=True)
+        g1 = make_ols_getter(non_canonical_resource)
+        self.assertIsNone(
+            g1,
+            msg="As of https://github.com/biopragmatics/bioregistry/pull/1935, `orpha` is "
+                "the canonical prefix with the OLS link",
+        )
+
+        canonical_resource = bioregistry.get_resource("orpha", strict=True)
+        g = make_ols_getter(canonical_resource)
+        self.assertIsNotNone(g)
+
+    def test_bad_lookup(self) -> None:
+        """Test looking up a missing key."""
+        self.assertIsNone(bioversions.get_version("asasgaasgagasg", strict=False))
+        with self.assertRaises(KeyError):
+            bioversions.get_version("asasgaasgagasg", strict=True)
+
     def test_get(self) -> None:
         """Test getters."""
         prefixes = [
             "reactome",
             "kegg",
+            "orphanet.ordo",
         ]
         for prefix in prefixes:
             with self.subTest(prefix=prefix):

--- a/tests/test_bioversions.py
+++ b/tests/test_bioversions.py
@@ -33,7 +33,7 @@ class TestGetter(unittest.TestCase):
         self.assertIsNone(
             g1,
             msg="As of https://github.com/biopragmatics/bioregistry/pull/1935, `orpha` is "
-                "the canonical prefix with the OLS link",
+            "the canonical prefix with the OLS link",
         )
 
         canonical_resource = bioregistry.get_resource("orpha", strict=True)


### PR DESCRIPTION
- Fix PathwayCommons getter
- Re-enable PathwayCommons and DisGeNet getters
- Refactor OLS getter constructor to use high-level `bioregistry.Resource` interface
- Skip constructing OLS getters for non-canonical resources (e.g., `orphanet.ordo`)
- Catch `KeyError` in `bioversions.get_version` for when a non-existent key is given
